### PR TITLE
Divide manhattan by 2

### DIFF
--- a/src/puzzle_state.py
+++ b/src/puzzle_state.py
@@ -155,12 +155,18 @@ class PuzzleState:
         elapsed = 0.0
 
         def compare_and_replace_state_in_list(state, state_list):
+            if has_smaller_f_in_list(state, state_list):
+                old_state_index = state_list.index(state)
+                state_list[old_state_index] = state
+
+        def has_smaller_f_in_list(state, state_list):
             old_state_index = state_list.index(state)
             old_state = state_list[old_state_index]
             old_state_f_value = old_state.get_f_value()
             state_f_value = state.get_f_value()
             if old_state_f_value > state_f_value:
-                state_list[old_state_index] = state
+                return True
+            return False
 
         while PuzzleState.hamming_distance(current_state, goal_state) != 0 and len(open_list) != 0:
             elapsed = time.time() - start_time
@@ -169,22 +175,22 @@ class PuzzleState:
             if elapsed > 60.0:
                 return None, None, elapsed
 
-            if current_state in closed_list:
-                if hasattr(heuristic_func, 'monotonic') and not heuristic_func.monotonic:
-                    compare_and_replace_state_in_list(current_state, closed_list)
-                del open_list[0]
-                continue
-
             for start in range(1, highest_value + 1):
                 next_best_states = current_state.get_next_states(start)
                 for state in next_best_states:
                     state.set_f_value(heuristic_func, goal_state)
-                    if state not in open_list:
-                        open_list.append(state)
-                    else:
+                    if state in closed_list:
+                        if (hasattr(heuristic_func, 'monotonic') and 
+                                not heuristic_func.monotonic and 
+                                has_smaller_f_in_list(state, closed_list)):
+                            open_list.append(state)
+                    elif state in open_list:
                         compare_and_replace_state_in_list(state, open_list)
+                    else:
+                        open_list.append(state)
 
             closed_list.append(current_state)
+            del open_list[0]
             open_list.sort(key=lambda x: x.get_f_value())
 
         if len(open_list) == 0:


### PR DESCRIPTION
Divide manhattan by 2 so it will be admissible.

These 3 puzzles previously gave a better solution for `hamming` than `manhattan`.
```
((3, 6, 8), (9, 2, 4), (5, 1, 7))
((4, 2, 5), (3, 6, 7), (1, 9, 8))
((4, 5, 6), (9, 8, 1), (7, 3, 2))
```
But when manhattan distance is divided by 2, manhattan will get the same solution as the hamming which the optimal one.
This change affects the order of the open list. 
Below is an example of the open list for the 3rd puzzle.

Format: `<state> <level> (f-value, h-value)`

<img src="https://user-images.githubusercontent.com/23142137/112742147-cf6fbd00-8f59-11eb-85c7-9c613b1ec98f.png" width=700>
